### PR TITLE
Make MatChipEditInput a Directive instead of a Component

### DIFF
--- a/src/dev-app/mdc-chips/mdc-chips-demo.html
+++ b/src/dev-app/mdc-chips/mdc-chips-demo.html
@@ -128,11 +128,16 @@
        {{disableInputs ? "Enable" : "Disable"}}
       </button>
 
+      <button mat-button (click)="editable = !editable">
+        {{editable ? "Disable editing" : "Enable editing"}}
+      </button>
+
       <h4>Input is last child of chip grid</h4>
 
       <mat-form-field class="demo-has-chip-list">
         <mat-chip-grid #chipGrid1 [(ngModel)]="selectedPeople" required [disabled]="disableInputs">
           <mat-chip-row *ngFor="let person of people"
+                   [editable]="editable"
                    (removed)="remove(person)">
             {{person.name}}
             <mat-icon matChipRemove>cancel</mat-icon>

--- a/src/dev-app/mdc-chips/mdc-chips-demo.html
+++ b/src/dev-app/mdc-chips/mdc-chips-demo.html
@@ -138,7 +138,8 @@
         <mat-chip-grid #chipGrid1 [(ngModel)]="selectedPeople" required [disabled]="disableInputs">
           <mat-chip-row *ngFor="let person of people"
                    [editable]="editable"
-                   (removed)="remove(person)">
+                   (removed)="remove(person)"
+                   (edited)="edit(person, $event)">
             {{person.name}}
             <mat-icon matChipRemove>cancel</mat-icon>
           </mat-chip-row>

--- a/src/dev-app/mdc-chips/mdc-chips-demo.ts
+++ b/src/dev-app/mdc-chips/mdc-chips-demo.ts
@@ -32,6 +32,7 @@ export class MdcChipsDemo {
   addOnBlur = true;
   disabledListboxes = false;
   disableInputs = false;
+  editable = false;
   message = '';
 
   // Enter, comma, semi-colon
@@ -79,6 +80,18 @@ export class MdcChipsDemo {
     if (index >= 0) {
       this.people.splice(index, 1);
     }
+  }
+
+  edit(person: Person, newValue: string): void {
+    if (newValue.trim().length === 0) {
+      this.remove(person);
+      return;
+    }
+
+    const index = this.people.indexOf(person);
+    const newPeople = this.people.slice();
+    newPeople[index] = {...newPeople[index], name: newValue};
+    this.people = newPeople;
   }
 
   toggleVisible(): void {

--- a/src/dev-app/mdc-chips/mdc-chips-demo.ts
+++ b/src/dev-app/mdc-chips/mdc-chips-demo.ts
@@ -9,7 +9,7 @@
 import {COMMA, ENTER} from '@angular/cdk/keycodes';
 import {Component} from '@angular/core';
 import {ThemePalette} from '@angular/material/core';
-import {MatChipInputEvent} from '@angular/material-experimental/mdc-chips';
+import {MatChipInputEvent, MatChipEditedEvent} from '@angular/material-experimental/mdc-chips';
 
 export interface Person {
   name: string;
@@ -82,15 +82,15 @@ export class MdcChipsDemo {
     }
   }
 
-  edit(person: Person, newValue: string): void {
-    if (newValue.trim().length === 0) {
+  edit(person: Person, event: MatChipEditedEvent): void {
+    if (event.value.trim().length === 0) {
       this.remove(person);
       return;
     }
 
     const index = this.people.indexOf(person);
     const newPeople = this.people.slice();
-    newPeople[index] = {...newPeople[index], name: newValue};
+    newPeople[index] = {...newPeople[index], name: event.value};
     this.people = newPeople;
   }
 

--- a/src/material-experimental/mdc-chips/chip-edit-input.html
+++ b/src/material-experimental/mdc-chips/chip-edit-input.html
@@ -1,0 +1,5 @@
+<span class="mdc-chip__primary-action mat-chip-edit-input"
+      role="textbox"
+      tabindex="-1"
+      contenteditable="true"
+      #inputElement></span>

--- a/src/material-experimental/mdc-chips/chip-edit-input.html
+++ b/src/material-experimental/mdc-chips/chip-edit-input.html
@@ -1,5 +1,0 @@
-<span class="mdc-chip__primary-action mat-chip-edit-input"
-      role="textbox"
-      tabindex="-1"
-      contenteditable="true"
-      #inputElement></span>

--- a/src/material-experimental/mdc-chips/chip-edit-input.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-edit-input.spec.ts
@@ -1,20 +1,12 @@
-import {Component, DebugElement, ViewChild, ElementRef} from '@angular/core';
+import {Component, DebugElement} from '@angular/core';
 import {async, TestBed, ComponentFixture} from '@angular/core/testing';
-import {
-  MAT_CHIP_EDIT_INPUT_MANAGER,
-  MatChipEditInput,
-  MatChipEditInputDestroyEvent,
-  MatChipEditInputInterface,
-  MatChipEditInputManager,
-  MatChipsModule,
-} from './index';
+import {MatChipEditInput, MatChipsModule} from './index';
 import {By} from '@angular/platform-browser';
 
 
 describe('MDC-based MatChipEditInput', () => {
   const DEFAULT_INITIAL_VALUE = 'INITIAL_VALUE';
 
-  let testComponent: ChipEditInputContainer;
   let fixture: ComponentFixture<any>;
   let inputDebugElement: DebugElement;
   let inputInstance: MatChipEditInput;
@@ -28,91 +20,33 @@ describe('MDC-based MatChipEditInput', () => {
     });
 
     TestBed.compileComponents();
-  }));
 
-  function initialize(initialValue = DEFAULT_INITIAL_VALUE) {
     fixture = TestBed.createComponent(ChipEditInputContainer);
-    testComponent = fixture.debugElement.componentInstance;
-
-    spyOn(testComponent, 'onUpdate');
-    spyOn(testComponent, 'onDestroy');
-    spyOn(testComponent, 'setMatChipEditInput');
-    spyOn(testComponent, 'clearMatChipEditInput');
-
-    testComponent.initialValue = initialValue;
-    testComponent.active = true;
-    fixture.detectChanges();
-
     inputDebugElement = fixture.debugElement.query(By.directive(MatChipEditInput))!;
     inputInstance = inputDebugElement.injector.get<MatChipEditInput>(MatChipEditInput);
-  }
+  }));
 
   describe('on initialization', () => {
     it('should set the initial input text', () => {
-      initialize();
+      inputInstance.initialize(DEFAULT_INITIAL_VALUE);
       expect(inputInstance.getNativeElement().textContent).toEqual(DEFAULT_INITIAL_VALUE);
     });
 
     it('should focus the input', () => {
-      initialize();
+      inputInstance.initialize(DEFAULT_INITIAL_VALUE);
       expect(document.activeElement).toEqual(inputInstance.getNativeElement());
     });
-
-    it('should register itself with the injected manager', () => {
-      initialize();
-      expect(testComponent.setMatChipEditInput).toHaveBeenCalledWith(inputInstance);
-    });
   });
 
-  describe('on destruction', () => {
-    it('should emit hadFocus: true if the input had focus', () => {
-      initialize();
-      testComponent.active = false;
-      fixture.detectChanges();
-      expect(testComponent.onDestroy).toHaveBeenCalledWith({hadFocus: true});
-    });
-
-    it('should emit hadFocus: false if the input did not have focus', () => {
-      initialize();
-      testComponent.otherFocus.nativeElement.focus();
-      testComponent.active = false;
-      fixture.detectChanges();
-      expect(testComponent.onDestroy).toHaveBeenCalledWith({hadFocus: false});
-    });
-
-    it('should clear the manager\'s input', () => {
-      initialize();
-      testComponent.active = false;
-      fixture.detectChanges();
-      expect(testComponent.clearMatChipEditInput).toHaveBeenCalled();
-    });
-  });
-
-  it('should emit a new value the input changes', () => {
-    initialize();
+  it('should update the internal value as it is set', () => {
+    inputInstance.initialize(DEFAULT_INITIAL_VALUE);
     const newValue = 'NEW_VALUE';
     inputInstance.setValue(newValue);
-    expect(testComponent.onUpdate).toHaveBeenCalledWith(newValue);
+    expect(inputInstance.getValue()).toEqual(newValue);
   });
 });
 
 @Component({
-  template: `<mat-chip-edit-input *ngIf="active"
-                                  [initialValue]="initialValue"
-                                  (updated)="onUpdate($event)"
-                                  (destroyed)="onDestroy($event)"></mat-chip-edit-input>
-             <button #otherFocus></button>`,
-  providers: [{provide: MAT_CHIP_EDIT_INPUT_MANAGER, useExisting: ChipEditInputContainer}],
+  template: `<span matChipEditInput></span>`,
 })
-class ChipEditInputContainer implements MatChipEditInputManager {
-  active = false;
-  initialValue = '';
-
-  @ViewChild('otherFocus') otherFocus!: ElementRef;
-
-  onUpdate: (value: string) => void = () => {};
-  onDestroy: (event: MatChipEditInputDestroyEvent) => void = () => {};
-
-  setMatChipEditInput: (value: MatChipEditInputInterface) => void = () => {};
-  clearMatChipEditInput: () => void = () => {};
-}
+class ChipEditInputContainer {}

--- a/src/material-experimental/mdc-chips/chip-edit-input.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-edit-input.spec.ts
@@ -1,6 +1,13 @@
 import {Component, DebugElement, ViewChild, ElementRef} from '@angular/core';
 import {async, TestBed, ComponentFixture} from '@angular/core/testing';
-import {MatChipsModule, MatChipEditInputDestroyEvent, MatChipEditInput, MatChipEditInputManager, MatChipEditInputInterface, MAT_CHIP_EDIT_INPUT_MANAGER} from './index';
+import {
+  MAT_CHIP_EDIT_INPUT_MANAGER,
+  MatChipEditInput,
+  MatChipEditInputDestroyEvent,
+  MatChipEditInputInterface,
+  MatChipEditInputManager,
+  MatChipsModule,
+} from './index';
 import {By} from '@angular/platform-browser';
 
 

--- a/src/material-experimental/mdc-chips/chip-edit-input.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-edit-input.spec.ts
@@ -1,0 +1,111 @@
+import {Component, DebugElement, ViewChild, ElementRef} from '@angular/core';
+import {async, TestBed, ComponentFixture} from '@angular/core/testing';
+import {MatChipsModule, MatChipEditInputDestroyEvent, MatChipEditInput, MatChipEditInputManager, MatChipEditInputInterface, MAT_CHIP_EDIT_INPUT_MANAGER} from './index';
+import {By} from '@angular/platform-browser';
+
+
+describe('MDC-based MatChipEditInput', () => {
+  const DEFAULT_INITIAL_VALUE = 'INITIAL_VALUE';
+
+  let testComponent: ChipEditInputContainer;
+  let fixture: ComponentFixture<any>;
+  let inputDebugElement: DebugElement;
+  let inputInstance: MatChipEditInput;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      imports: [MatChipsModule],
+      declarations: [
+        ChipEditInputContainer,
+      ],
+    });
+
+    TestBed.compileComponents();
+  }));
+
+  function initialize(initialValue = DEFAULT_INITIAL_VALUE) {
+    fixture = TestBed.createComponent(ChipEditInputContainer);
+    testComponent = fixture.debugElement.componentInstance;
+
+    spyOn(testComponent, 'onUpdate');
+    spyOn(testComponent, 'onDestroy');
+    spyOn(testComponent, 'setMatChipEditInput');
+    spyOn(testComponent, 'clearMatChipEditInput');
+
+    testComponent.initialValue = initialValue;
+    testComponent.active = true;
+    fixture.detectChanges();
+
+    inputDebugElement = fixture.debugElement.query(By.directive(MatChipEditInput))!;
+    inputInstance = inputDebugElement.injector.get<MatChipEditInput>(MatChipEditInput);
+  }
+
+  describe('on initialization', () => {
+    it('should set the initial input text', () => {
+      initialize();
+      expect(inputInstance.getNativeElement().textContent).toEqual(DEFAULT_INITIAL_VALUE);
+    });
+
+    it('should focus the input', () => {
+      initialize();
+      expect(document.activeElement).toEqual(inputInstance.getNativeElement());
+    });
+
+    it('should register itself with the injected manager', () => {
+      initialize();
+      expect(testComponent.setMatChipEditInput).toHaveBeenCalledWith(inputInstance);
+    });
+  });
+
+  describe('on destruction', () => {
+    it('should emit hadFocus: true if the input had focus', () => {
+      initialize();
+      testComponent.active = false;
+      fixture.detectChanges();
+      expect(testComponent.onDestroy).toHaveBeenCalledWith({hadFocus: true});
+    });
+
+    it('should emit hadFocus: false if the input did not have focus', () => {
+      initialize();
+      testComponent.otherFocus.nativeElement.focus();
+      testComponent.active = false;
+      fixture.detectChanges();
+      expect(testComponent.onDestroy).toHaveBeenCalledWith({hadFocus: false});
+    });
+
+    it('should clear the manager\'s input', () => {
+      initialize();
+      testComponent.active = false;
+      fixture.detectChanges();
+      expect(testComponent.clearMatChipEditInput).toHaveBeenCalled();
+    });
+  });
+
+  it('should emit a new value the input changes', () => {
+    initialize();
+    const newValue = 'NEW_VALUE';
+    inputInstance.setValue(newValue);
+    expect(testComponent.onUpdate).toHaveBeenCalledWith(newValue);
+  });
+});
+
+@Component({
+  template: `<mat-chip-edit-input *ngIf="active"
+                                  [initialValue]="initialValue"
+                                  (updated)="onUpdate($event)"
+                                  (destroyed)="onDestroy($event)"></mat-chip-edit-input>
+             <button #otherFocus></button>`,
+  providers: [{provide: MAT_CHIP_EDIT_INPUT_MANAGER, useExisting: ChipEditInputContainer}],
+})
+class ChipEditInputContainer implements MatChipEditInputManager {
+  active = false;
+  initialValue = '';
+
+  @ViewChild('otherFocus') otherFocus!: ElementRef;
+
+  onUpdate: (value: string) => void = () => {};
+  onDestroy: (event: MatChipEditInputDestroyEvent) => void = () => {};
+
+  setMatChipEditInput: (value: MatChipEditInputInterface) => void = () => {};
+  clearMatChipEditInput: () => void = () => {};
+}

--- a/src/material-experimental/mdc-chips/chip-edit-input.ts
+++ b/src/material-experimental/mdc-chips/chip-edit-input.ts
@@ -7,101 +7,44 @@
  */
 
 import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
+  Directive,
   ElementRef,
-  EventEmitter,
-  Inject,
-  InjectionToken,
-  Input,
-  OnDestroy,
-  Optional,
-  Output,
-  ViewChild,
-  ViewEncapsulation,
 } from '@angular/core';
 
-export interface MatChipEditInputDestroyEvent {
-  hadFocus: boolean;
-}
-
-export interface MatChipEditInputManager {
-  setMatChipEditInput(value: MatChipEditInputInterface): void;
-  clearMatChipEditInput(): void;
-}
-
-export const MAT_CHIP_EDIT_INPUT_MANAGER =
-    new InjectionToken<MatChipEditInputManager>('MAT_CHIP_EDIT_INPUT_MANAGER');
-
-export interface MatChipEditInputInterface {
-  getNativeElement(): HTMLElement;
-  setValue(value: string): void;
-}
-
 /**
- * A component that handles editing an existing chip and exposes itself to an optional injected
- * manager so parent components can extend the editing behavior.
+ * A directive that makes a span editable and exposes functions to modify and retrieve the
+ * element's contents.
  */
-@Component({
-  selector: 'mat-chip-edit-input',
-  templateUrl: 'chip-edit-input.html',
-  styleUrls: ['chips.css'],
-  inputs: ['initialValue'],
+@Directive({
+  selector: 'span[matChipEditInput]',
   host: {
-    '(input)': '_onInput()',
+    'class': 'mdc-chip__primary-action mat-chip-edit-input',
+    'role': 'textbox',
+    'tabindex': '-1',
+    'contenteditable': 'true',
   },
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatChipEditInput implements AfterViewInit, OnDestroy, MatChipEditInputInterface {
-  @Input() initialValue = '';
-
-  @Output() readonly updated = new EventEmitter<string>();
-
-  @Output() readonly destroyed = new EventEmitter<MatChipEditInputDestroyEvent>();
-
-  @ViewChild('inputElement') inputElement!: ElementRef;
-
+export class MatChipEditInput {
   constructor(
-      @Optional() @Inject(MAT_CHIP_EDIT_INPUT_MANAGER)
-      private readonly _inputManager: MatChipEditInputManager,
-  ) {
-    if (_inputManager) {
-      _inputManager.setMatChipEditInput(this);
-    }
-  }
+      private readonly _elementRef: ElementRef,
+  ) {}
 
-  ngAfterViewInit() {
-    this.getNativeElement().innerText = this.initialValue;
+  initialize(initialValue: string) {
     this.getNativeElement().focus();
-    this._moveCursorToEndOfInput();
-  }
-
-  ngOnDestroy() {
-    this.destroyed.emit({
-      // We assume the input had focus if it is still the active element or the body
-      // has become the active element on destroy.
-      hadFocus: document.activeElement === this.getNativeElement() ||
-                document.activeElement === document.body,
-    });
-    if (this._inputManager) {
-      this._inputManager.clearMatChipEditInput();
-    }
+    this.setValue(initialValue);
   }
 
   getNativeElement(): HTMLElement {
-    return this.inputElement.nativeElement;
+    return this._elementRef.nativeElement;
   }
 
   setValue(value: string) {
     this.getNativeElement().innerText = value;
-    this._onInput();
+    this._moveCursorToEndOfInput();
   }
 
-  _onInput() {
-    this.updated.emit(
-        this.getNativeElement().textContent!.trim());
+  getValue(): string {
+    return this.getNativeElement().textContent || '';
   }
 
   private _moveCursorToEndOfInput() {

--- a/src/material-experimental/mdc-chips/chip-edit-input.ts
+++ b/src/material-experimental/mdc-chips/chip-edit-input.ts
@@ -49,7 +49,7 @@ export interface MatChipEditInputInterface {
   styleUrls: ['chips.css'],
   inputs: ['initialValue'],
   host: {
-    '(input)': '_onInput($event)',
+    '(input)': '_onInput()',
   },
   encapsulation: ViewEncapsulation.None,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/src/material-experimental/mdc-chips/chip-edit-input.ts
+++ b/src/material-experimental/mdc-chips/chip-edit-input.ts
@@ -1,0 +1,115 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  EventEmitter,
+  Inject,
+  InjectionToken,
+  Input,
+  OnDestroy,
+  Optional,
+  Output,
+  ViewChild,
+  ViewEncapsulation,
+} from '@angular/core';
+
+export interface MatChipEditInputDestroyEvent {
+  hadFocus: boolean;
+}
+
+export interface MatChipEditInputManager {
+  setMatChipEditInput(value: MatChipEditInputInterface): void;
+  clearMatChipEditInput(): void;
+}
+
+export const MAT_CHIP_EDIT_INPUT_MANAGER =
+    new InjectionToken<MatChipEditInputManager>('MAT_CHIP_EDIT_INPUT_MANAGER');
+
+export interface MatChipEditInputInterface {
+  getNativeElement(): HTMLElement;
+  setValue(value: string): void;
+}
+
+/**
+ * A component that handles editing an existing chip and exposes itself to an optional injected
+ * manager so parent components can extend the editing behavior.
+ */
+@Component({
+  selector: 'mat-chip-edit-input',
+  templateUrl: 'chip-edit-input.html',
+  styleUrls: ['chips.css'],
+  inputs: ['initialValue'],
+  host: {
+    '(input)': '_onInput($event)',
+  },
+  encapsulation: ViewEncapsulation.None,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MatChipEditInput implements AfterViewInit, OnDestroy, MatChipEditInputInterface {
+  @Input() initialValue = '';
+
+  @Output() readonly updated = new EventEmitter<string>();
+
+  @Output() readonly destroyed = new EventEmitter<MatChipEditInputDestroyEvent>();
+
+  @ViewChild('inputElement') inputElement!: ElementRef;
+
+  constructor(
+      @Optional() @Inject(MAT_CHIP_EDIT_INPUT_MANAGER)
+      private readonly _inputManager: MatChipEditInputManager,
+  ) {
+    if (_inputManager) {
+      _inputManager.setMatChipEditInput(this);
+    }
+  }
+
+  ngAfterViewInit() {
+    this.getNativeElement().innerText = this.initialValue;
+    this.getNativeElement().focus();
+    this._moveCursorToEndOfInput();
+  }
+
+  ngOnDestroy() {
+    this.destroyed.emit({
+      // We assume the input had focus if it is still the active element or the body
+      // has become the active element on destroy.
+      hadFocus: document.activeElement === this.getNativeElement() ||
+                document.activeElement === document.body,
+    });
+    if (this._inputManager) {
+      this._inputManager.clearMatChipEditInput();
+    }
+  }
+
+  getNativeElement(): HTMLElement {
+    return this.inputElement.nativeElement;
+  }
+
+  setValue(value: string) {
+    this.getNativeElement().innerText = value;
+    this._onInput();
+  }
+
+  _onInput() {
+    this.updated.emit(
+        this.getNativeElement().textContent!.trim());
+  }
+
+  private _moveCursorToEndOfInput() {
+    const range = document.createRange();
+    range.selectNodeContents(this.getNativeElement());
+    range.collapse(false);
+    const sel = window.getSelection()!;
+    sel.removeAllRanges();
+    sel.addRange(range);
+  }
+}

--- a/src/material-experimental/mdc-chips/chip-grid.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.spec.ts
@@ -509,16 +509,12 @@ describe('MDC-based MatChipGrid', () => {
 
         const array = chips.toArray();
         const firstItem = array[0];
-        const nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
-        const firstNativeChip = nativeChips[0] as HTMLElement;
         firstItem.focus();
-        const primaryActionElement = firstNativeChip.querySelector('.mdc-chip__primary-action')!;
-        firstItem._keydown(createKeyboardEvent('keydown', ENTER, 'Enter', primaryActionElement));
+        firstItem._keydown(createKeyboardEvent('keydown', ENTER, 'Enter', document.activeElement!));
         fixture.detectChanges();
 
-        expect(firstNativeChip.classList).toContain('mdc-chip--editing');
-        expect(manager.activeRowIndex).toBe(0);
-        expect(manager.activeColumnIndex).toBe(0);
+        const activeRowIndex = manager.activeRowIndex;
+        const activeColumnIndex = manager.activeColumnIndex;
 
         const KEYS_TO_IGNORE = [HOME, END, LEFT_ARROW, RIGHT_ARROW];
         for (const key of KEYS_TO_IGNORE) {
@@ -527,8 +523,8 @@ describe('MDC-based MatChipGrid', () => {
           chipGridInstance._keydown(event);
           fixture.detectChanges();
 
-          expect(manager.activeRowIndex).toBe(0);
-          expect(manager.activeColumnIndex).toBe(0);
+          expect(manager.activeRowIndex).toBe(activeRowIndex);
+          expect(manager.activeColumnIndex).toBe(activeColumnIndex);
         }
       });
     });

--- a/src/material-experimental/mdc-chips/chip-grid.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.spec.ts
@@ -511,13 +511,12 @@ describe('MDC-based MatChipGrid', () => {
         const firstItem = array[0];
         const nativeChips = chipGridNativeElement.querySelectorAll('mat-chip-row');
         const firstNativeChip = nativeChips[0] as HTMLElement;
-
+        firstItem.focus();
         const primaryActionElement = firstNativeChip.querySelector('.mdc-chip__primary-action')!;
-        const editingStartEvent =
-          createKeyboardEvent('keydown', ENTER, 'Enter', primaryActionElement);
-        firstItem._keydown(editingStartEvent);
+        firstItem._keydown(createKeyboardEvent('keydown', ENTER, 'Enter', primaryActionElement));
         fixture.detectChanges();
 
+        expect(firstNativeChip.classList).toContain('mdc-chip--editing');
         expect(manager.activeRowIndex).toBe(0);
         expect(manager.activeColumnIndex).toBe(0);
 

--- a/src/material-experimental/mdc-chips/chip-grid.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.spec.ts
@@ -191,7 +191,7 @@ describe('MDC-based MatChipGrid', () => {
 
           // Focus and blur the middle item
           midItem.focus();
-          (document.activeElement as HTMLElement|null)?.blur();
+          (document.activeElement as HTMLElement).blur();
           tick();
           zone.simulateZoneExit();
 

--- a/src/material-experimental/mdc-chips/chip-grid.ts
+++ b/src/material-experimental/mdc-chips/chip-grid.ts
@@ -405,15 +405,16 @@ export class MatChipGrid extends _MatChipGridMixinBase implements AfterContentIn
     const target = event.target as HTMLElement;
     const keyCode = event.keyCode;
     const manager = this._keyManager;
-
-    // If they are on an empty input and hit backspace, focus the last chip
-    if (keyCode === BACKSPACE && this._isEmptyInput(target)) {
+    if (keyCode === TAB && target.id !== this._chipInput!.id) {
+      this._allowFocusEscape();
+    } else if (this._originatesFromEditingChip(event)) {
+      // No-op, let the editing chip handle all keyboard events except for Tab.
+    } else if (keyCode === BACKSPACE && this._isEmptyInput(target)) {
+      // If they are on an empty input and hit backspace, focus the last chip
       if (this._chips.length) {
         manager.setLastCellActive();
       }
       event.preventDefault();
-    } else if (keyCode === TAB && target.id !== this._chipInput!.id ) {
-      this._allowFocusEscape();
     } else if (this._originatesFromChip(event)) {
       if (keyCode === HOME) {
         manager.setFirstCellActive();

--- a/src/material-experimental/mdc-chips/chip-row.html
+++ b/src/material-experimental/mdc-chips/chip-row.html
@@ -24,9 +24,9 @@
 </div>
 
 <div *ngIf="_isEditing()" role="gridcell" class="mat-chip-edit-input-container">
-  <ng-content *ngIf="contentEditInput; else defaultMatChipEditInput" select="[matChipEditInput]"></ng-content>
+  <ng-content *ngIf="contentEditInput; else defaultMatChipEditInput"
+              select="[matChipEditInput]"></ng-content>
+  <ng-template #defaultMatChipEditInput>
+    <span matChipEditInput></span>
+  </ng-template>
 </div>
-
-<ng-template #defaultMatChipEditInput>
-  <span matChipEditInput></span>
-</ng-template>

--- a/src/material-experimental/mdc-chips/chip-row.html
+++ b/src/material-experimental/mdc-chips/chip-row.html
@@ -24,7 +24,9 @@
 </div>
 
 <div *ngIf="_isEditing()" role="gridcell" class="mat-chip-edit-input-container">
-  <mat-chip-edit-input [initialValue]="_editingValue"
-                       (updated)="_onInputUpdated($event)"
-                       (destroyed)="_onInputDestroyed($event)"></mat-chip-edit-input>
+  <ng-content *ngIf="contentEditInput; else defaultMatChipEditInput" select="[matChipEditInput]"></ng-content>
 </div>
+
+<ng-template #defaultMatChipEditInput>
+  <span matChipEditInput></span>
+</ng-template>

--- a/src/material-experimental/mdc-chips/chip-row.html
+++ b/src/material-experimental/mdc-chips/chip-row.html
@@ -1,19 +1,30 @@
-<span class="mdc-chip__ripple"></span>
+<ng-container *ngIf="!_isEditing()">
+  <span class="mdc-chip__ripple"></span>
 
-<span matRipple class="mat-mdc-chip-ripple"
-     [matRippleAnimation]="_rippleAnimation"
-     [matRippleDisabled]="_isRippleDisabled()"
-     [matRippleCentered]="_isRippleCentered"
-     [matRippleTrigger]="_elementRef.nativeElement"></span>
+  <span matRipple class="mat-mdc-chip-ripple"
+       [matRippleAnimation]="_rippleAnimation"
+       [matRippleDisabled]="_isRippleDisabled()"
+       [matRippleCentered]="_isRippleCentered"
+       [matRippleTrigger]="_elementRef.nativeElement"></span>
+</ng-container>
 
-<div role="gridcell">
-  <div #chipContent tabindex="-1"
-       class="mat-chip-row-focusable-text-content mat-mdc-focus-indicator">
-  	 <ng-content select="mat-chip-avatar, [matChipAvatar]"></ng-content>
-  	 <span class="mdc-chip__text"><ng-content></ng-content></span>
-  	 <ng-content select="mat-chip-trailing-icon,[matChipTrailingIcon]"></ng-content>
+<div class="mat-chip-content">
+  <div role="gridcell">
+    <div #chipContent tabindex="-1"
+         class="mat-chip-row-focusable-text-content mat-mdc-focus-indicator mdc-chip__primary-action"
+         [attr.role]="editable ? 'button' : null">
+      <ng-content select="mat-chip-avatar, [matChipAvatar]"></ng-content>
+      <span class="mdc-chip__text"><ng-content></ng-content></span>
+      <ng-content select="mat-chip-trailing-icon,[matChipTrailingIcon]"></ng-content>
+    </div>
+  </div>
+  <div role="gridcell" *ngIf="removeIcon">
+    <ng-content select="[matChipRemove]"></ng-content>
   </div>
 </div>
-<div role="gridcell" *ngIf="removeIcon">
-  <ng-content select="[matChipRemove]"></ng-content>
+
+<div *ngIf="_isEditing()" role="gridcell" class="mat-chip-edit-input-container">
+  <mat-chip-edit-input [initialValue]="_editingValue"
+                       (updated)="_onInputUpdated($event)"
+                       (destroyed)="_onInputDestroyed($event)"></mat-chip-edit-input>
 </div>

--- a/src/material-experimental/mdc-chips/chip-row.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-row.spec.ts
@@ -1,5 +1,5 @@
 import {Directionality} from '@angular/cdk/bidi';
-import {BACKSPACE, DELETE} from '@angular/cdk/keycodes';
+import {BACKSPACE, DELETE, RIGHT_ARROW} from '@angular/cdk/keycodes';
 import {
   createKeyboardEvent,
   createFakeEvent,
@@ -9,7 +9,7 @@ import {Component, DebugElement, ViewChild} from '@angular/core';
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {Subject} from 'rxjs';
-import {MatChipEvent, MatChipGrid, MatChipRow, MatChipsModule} from './index';
+import {MatChipEvent, MatChipGrid, MatChipRemove, MatChipRow, MatChipsModule} from './index';
 
 
 describe('MDC-based Row Chips', () => {
@@ -17,6 +17,7 @@ describe('MDC-based Row Chips', () => {
   let chipDebugElement: DebugElement;
   let chipNativeElement: HTMLElement;
   let chipInstance: MatChipRow;
+  let removeIconInstance: MatChipRemove;
 
   let dir = 'ltr';
 
@@ -46,6 +47,9 @@ describe('MDC-based Row Chips', () => {
       chipNativeElement = chipDebugElement.nativeElement;
       chipInstance = chipDebugElement.injector.get<MatChipRow>(MatChipRow);
       testComponent = fixture.debugElement.componentInstance;
+
+      const removeIconDebugElement = fixture.debugElement.query(By.directive(MatChipRemove))!;
+      removeIconInstance = removeIconDebugElement.injector.get<MatChipRemove>(MatChipRemove);
     });
 
     describe('basic behaviors', () => {
@@ -135,6 +139,21 @@ describe('MDC-based Row Chips', () => {
 
           expect(testComponent.chipRemove).toHaveBeenCalled();
         });
+
+        it('arrow key navigation does not emit the (removed) event', () => {
+          const ARROW_KEY_EVENT = createKeyboardEvent('keydown', RIGHT_ARROW) as KeyboardEvent;
+
+          spyOn(testComponent, 'chipRemove');
+
+          removeIconInstance.interaction.next(ARROW_KEY_EVENT);
+          fixture.detectChanges();
+
+          const fakeEvent = createFakeEvent('transitionend');
+          (fakeEvent as any).propertyName = 'width';
+          chipNativeElement.dispatchEvent(fakeEvent);
+
+          expect(testComponent.chipRemove).not.toHaveBeenCalled();
+        });
       });
 
       describe('when removable is false', () => {
@@ -219,6 +238,7 @@ describe('MDC-based Row Chips', () => {
                  (focus)="chipFocus($event)" (destroyed)="chipDestroy($event)"
                  (removed)="chipRemove($event)">
           {{name}}
+          <button matChipRemove>x</button>
         </mat-chip-row>
         <input matInput [matChipInputFor]="chipGrid">
       </div>

--- a/src/material-experimental/mdc-chips/chip-row.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-row.spec.ts
@@ -6,12 +6,13 @@ import {
   createFakeEvent,
   dispatchFakeEvent,
 } from '@angular/cdk/testing/private';
-import {Component, DebugElement, ViewChild} from '@angular/core';
+import {Component, DebugElement, ElementRef, ViewChild} from '@angular/core';
 import {async, ComponentFixture, TestBed, flush, fakeAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {Subject} from 'rxjs';
 import {
   MatChipEditedEvent,
+  MatChipEditInput,
   MatChipEvent,
   MatChipGrid,
   MatChipRemove,
@@ -259,11 +260,21 @@ describe('MDC-based Row Chips', () => {
     });
 
     describe('editing behavior', () => {
+      let editInputInstance: MatChipEditInput;
+      let chipContentElement: HTMLElement;
+
       beforeEach(() => {
         testComponent.editable = true;
         fixture.detectChanges();
         chipInstance._dblclick(createMouseEvent('dblclick'));
         spyOn(testComponent, 'chipEdit');
+        fixture.detectChanges();
+
+        const editInputDebugElement = fixture.debugElement.query(By.directive(MatChipEditInput))!;
+        editInputInstance = editInputDebugElement.injector.get<MatChipEditInput>(MatChipEditInput);
+
+        chipContentElement =
+          chipNativeElement.querySelector('.mat-chip-row-focusable-text-content') as HTMLElement;
       });
 
       function keyDownOnPrimaryAction(keyCode: number, key: string) {
@@ -303,10 +314,33 @@ describe('MDC-based Row Chips', () => {
 
       it('should emit the new chip value when editing completes', () => {
         const chipValue = 'chip value';
-        chipInstance._onInputUpdated(chipValue);
+        editInputInstance.setValue(chipValue);
         keyDownOnPrimaryAction(ENTER, 'Enter');
         const expectedValue = jasmine.objectContaining({value: chipValue});
         expect(testComponent.chipEdit).toHaveBeenCalledWith(expectedValue);
+      });
+
+      it('should focus the chip content if the edit input has focus on completion', () => {
+        const chipValue = 'chip value';
+        editInputInstance.setValue(chipValue);
+        keyDownOnPrimaryAction(ENTER, 'Enter');
+        expect(document.activeElement).toBe(chipContentElement);
+      });
+
+      it('should focus the chip content if the body has focus on completion', () => {
+        const chipValue = 'chip value';
+        editInputInstance.setValue(chipValue);
+        (document.activeElement as HTMLElement).blur();
+        keyDownOnPrimaryAction(ENTER, 'Enter');
+        expect(document.activeElement).toBe(chipContentElement);
+      });
+
+      it('should not change focus if another element has focus on completion', () => {
+        const chipValue = 'chip value';
+        editInputInstance.setValue(chipValue);
+        testComponent.chipInput.nativeElement.focus();
+        keyDownOnPrimaryAction(ENTER, 'Enter');
+        expect(document.activeElement).not.toBe(chipContentElement);
       });
     });
   });
@@ -322,13 +356,15 @@ describe('MDC-based Row Chips', () => {
                  (removed)="chipRemove($event)" (edited)="chipEdit($event)">
           {{name}}
           <button matChipRemove>x</button>
+          <span matChipEditInput></span>
         </mat-chip-row>
-        <input matInput [matChipInputFor]="chipGrid">
+        <input matInput [matChipInputFor]="chipGrid" #chipInput>
       </div>
     </mat-chip-grid>`
 })
 class SingleChip {
   @ViewChild(MatChipGrid) chipList: MatChipGrid;
+  @ViewChild('chipInput') chipInput: ElementRef;
   disabled: boolean = false;
   name: string = 'Test';
   color: string = 'primary';

--- a/src/material-experimental/mdc-chips/chip-row.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-row.spec.ts
@@ -320,6 +320,22 @@ describe('MDC-based Row Chips', () => {
         expect(testComponent.chipEdit).toHaveBeenCalledWith(expectedValue);
       });
 
+      it('should use the projected edit input if provided', () => {
+        expect(editInputInstance.getNativeElement()).toHaveClass('projected-edit-input');
+      });
+
+      it('should use the default edit input if none is projected', () => {
+        keyDownOnPrimaryAction(ENTER, 'Enter');
+        testComponent.useCustomEditInput = false;
+        fixture.detectChanges();
+        chipInstance._dblclick(createMouseEvent('dblclick'));
+        fixture.detectChanges();
+        const editInputDebugElement = fixture.debugElement.query(By.directive(MatChipEditInput))!;
+        const editInputNoProject =
+          editInputDebugElement.injector.get<MatChipEditInput>(MatChipEditInput);
+        expect(editInputNoProject.getNativeElement()).not.toHaveClass('projected-edit-input');
+      });
+
       it('should focus the chip content if the edit input has focus on completion', () => {
         const chipValue = 'chip value';
         editInputInstance.setValue(chipValue);
@@ -356,7 +372,7 @@ describe('MDC-based Row Chips', () => {
                  (removed)="chipRemove($event)" (edited)="chipEdit($event)">
           {{name}}
           <button matChipRemove>x</button>
-          <span matChipEditInput></span>
+          <span *ngIf="useCustomEditInput" class="projected-edit-input" matChipEditInput></span>
         </mat-chip-row>
         <input matInput [matChipInputFor]="chipGrid" #chipInput>
       </div>
@@ -371,6 +387,7 @@ class SingleChip {
   removable: boolean = true;
   shouldShow: boolean = true;
   editable: boolean = false;
+  useCustomEditInput: boolean = true;
 
   chipFocus: (event?: MatChipEvent) => void = () => {};
   chipDestroy: (event?: MatChipEvent) => void = () => {};

--- a/src/material-experimental/mdc-chips/chip-row.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-row.spec.ts
@@ -10,8 +10,14 @@ import {Component, DebugElement, ViewChild} from '@angular/core';
 import {async, ComponentFixture, TestBed, flush, fakeAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {Subject} from 'rxjs';
-import {MatChipEvent, MatChipEditedEvent, MatChipGrid, MatChipRemove, MatChipRow, MatChipsModule} from './index';
-import { MatChipEditInput } from './chip-edit-input';
+import {
+  MatChipEditedEvent,
+  MatChipEvent,
+  MatChipGrid,
+  MatChipRemove,
+  MatChipRow,
+  MatChipsModule,
+} from './index';
 
 
 describe('MDC-based Row Chips', () => {

--- a/src/material-experimental/mdc-chips/chip-row.ts
+++ b/src/material-experimental/mdc-chips/chip-row.ts
@@ -17,7 +17,7 @@ import {
   ViewEncapsulation
 } from '@angular/core';
 import {MatChip} from './chip';
-import {GridKeyManagerRow, NAVIGATION_KEYS} from './grid-key-manager';
+import {GridKeyManagerRow} from './grid-key-manager';
 
 
 /**
@@ -60,9 +60,6 @@ export class MatChipRow extends MatChip implements AfterContentInit, AfterViewIn
 
   /** The focusable grid cells for this row. Implemented as part of GridKeyManagerRow. */
   cells!: HTMLElement[];
-
-  /** Key codes for which this component has a custom handler. */
-  HANDLED_KEYS: Set<number> = new Set([...NAVIGATION_KEYS, BACKSPACE, DELETE]);
 
   ngAfterContentInit() {
     super.ngAfterContentInit();

--- a/src/material-experimental/mdc-chips/chip-set.ts
+++ b/src/material-experimental/mdc-chips/chip-set.ts
@@ -297,11 +297,23 @@ export class MatChipSet extends _MatChipSetMixinBase implements AfterContentInit
 
   /** Checks whether an event comes from inside a chip element. */
   protected _originatesFromChip(event: Event): boolean {
+    return this._checkForClassInHierarchy(event, 'mdc-chip');
+  }
+
+  /**
+   * Checks whether an event comes from inside a chip element in the editing
+   * state.
+   */
+  protected _originatesFromEditingChip(event: Event): boolean {
+    return this._checkForClassInHierarchy(event, 'mdc-chip--editing');
+  }
+
+  private _checkForClassInHierarchy(event: Event, className: string) {
     let currentElement = event.target as HTMLElement | null;
 
     while (currentElement && currentElement !== this._elementRef.nativeElement) {
       // Null check the classList, because IE and Edge don't support it on all elements.
-      if (currentElement.classList && currentElement.classList.contains('mdc-chip')) {
+      if (currentElement.classList && currentElement.classList.contains(className)) {
         return true;
       }
 

--- a/src/material-experimental/mdc-chips/chip.ts
+++ b/src/material-experimental/mdc-chips/chip.ts
@@ -131,7 +131,7 @@ export class MatChip extends _MatChipMixinBase implements AfterContentInit, Afte
   /** Emits when the chip is blurred. */
   readonly _onBlur = new Subject<MatChipEvent>();
 
-  readonly HANDLED_KEYS: Set<number> = new Set([SPACE, ENTER]);
+  readonly REMOVE_ICON_HANDLED_KEYS: Set<number> = new Set([SPACE, ENTER]);
 
   /** Whether this chip is a basic (unstyled) chip. */
   readonly _isBasicChip: boolean;
@@ -385,7 +385,7 @@ export class MatChip extends _MatChipMixinBase implements AfterContentInit, Afte
           const isKeyboardEvent = event.type.startsWith('key');
 
           if (this.disabled || (isKeyboardEvent &&
-              !this.HANDLED_KEYS.has((event as KeyboardEvent).keyCode))) {
+              !this.REMOVE_ICON_HANDLED_KEYS.has((event as KeyboardEvent).keyCode))) {
             return;
           }
 

--- a/src/material-experimental/mdc-chips/chip.ts
+++ b/src/material-experimental/mdc-chips/chip.ts
@@ -146,9 +146,6 @@ export class MatChip extends _MatChipMixinBase implements AfterContentInit, Afte
   /** Whether the chip has focus. */
   protected _hasFocusInternal = false;
 
-  /** The value of the chip as it is being edited. */
-  protected _editingValueInternal = '';
-
     /** Whether animations for the chip are enabled. */
   _animationsDisabled: boolean;
 
@@ -164,10 +161,6 @@ export class MatChip extends _MatChipMixinBase implements AfterContentInit, Afte
 
   get _hasFocus() {
     return this._hasFocusInternal;
-  }
-
-  get _editingValue() {
-    return this._editingValueInternal;
   }
 
   /** Default unique id for the chip. */
@@ -301,13 +294,12 @@ export class MatChip extends _MatChipMixinBase implements AfterContentInit, Afte
         },
     notifyEditStart:
         () => {
-          this._editingValueInternal = this.value;
+          this._onEditStart();
           this._changeDetectorRef.markForCheck();
         },
     notifyEditFinish:
         () => {
-          this.edited.emit({chip: this, value: this._editingValue});
-          this._editingValueInternal = '';
+          this._onEditFinish();
           this._changeDetectorRef.markForCheck();
         },
     getComputedStyleValue:
@@ -494,6 +486,12 @@ export class MatChip extends _MatChipMixinBase implements AfterContentInit, Afte
   _isEditing() {
     return this._chipFoundation.isEditing();
   }
+
+  /** Overridden by MatChipRow. */
+  protected _onEditStart() {}
+
+  /** Overridden by MatChipRow. */
+  protected _onEditFinish() {}
 
   static ngAcceptInputType_disabled: BooleanInput;
   static ngAcceptInputType_removable: BooleanInput;

--- a/src/material-experimental/mdc-chips/chips.scss
+++ b/src/material-experimental/mdc-chips/chips.scss
@@ -117,3 +117,31 @@ input.mat-mdc-chip-input {
 .mat-chip-row-focusable-text-content {
   position: relative;
 }
+
+.mat-chip-content {
+  display: inline-flex;
+}
+
+.mdc-chip--editing {
+  background-color: transparent;
+  display: flex;
+  flex-direction: column;
+
+  .mat-chip-content {
+    pointer-events: none;
+    height: 0;
+    overflow: hidden;
+  }
+}
+
+.mat-chip-edit-input {
+  cursor: text;
+  display: inline-block;
+}
+
+.mat-chip-edit-input-container {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+}

--- a/src/material-experimental/mdc-chips/module.ts
+++ b/src/material-experimental/mdc-chips/module.ts
@@ -12,6 +12,7 @@ import {NgModule} from '@angular/core';
 import {ErrorStateMatcher, MatCommonModule, MatRippleModule} from '@angular/material/core';
 import {MatChip, MatChipCssInternalOnly} from './chip';
 import {MAT_CHIPS_DEFAULT_OPTIONS, MatChipsDefaultOptions} from './chip-default-options';
+import {MatChipEditInput} from './chip-edit-input';
 import {MatChipGrid} from './chip-grid';
 import {MatChipAvatar, MatChipRemove, MatChipTrailingIcon} from './chip-icons';
 import {MatChipInput} from './chip-input';
@@ -25,6 +26,7 @@ const CHIP_DECLARATIONS = [
   MatChip,
   MatChipAvatar,
   MatChipCssInternalOnly,
+  MatChipEditInput,
   MatChipGrid,
   MatChipInput,
   MatChipListbox,

--- a/src/material-experimental/mdc-chips/public-api.ts
+++ b/src/material-experimental/mdc-chips/public-api.ts
@@ -17,3 +17,4 @@ export * from './chip-input';
 export * from './chip-default-options';
 export * from './chip-icons';
 export * from './chip-text-control';
+export * from './chip-edit-input';


### PR DESCRIPTION
Changes matChipEditInput into a directive to better match established patterns used by things like matChipRemove to dictate the behavior of an edit input from within a chip while still letting the host component have some control over the input.