### PR TITLE
Make MatChipEditInput a Directive instead of a Component

### DIFF
--- a/src/material-experimental/mdc-chips/chip-edit-input.html
+++ b/src/material-experimental/mdc-chips/chip-edit-input.html
@@ -1,5 +1,0 @@
-<span class="mdc-chip__primary-action mat-chip-edit-input"
-      role="textbox"
-      tabindex="-1"
-      contenteditable="true"
-      #inputElement></span>

--- a/src/material-experimental/mdc-chips/chip-edit-input.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-edit-input.spec.ts
@@ -1,20 +1,12 @@
-import {Component, DebugElement, ViewChild, ElementRef} from '@angular/core';
+import {Component, DebugElement} from '@angular/core';
 import {async, TestBed, ComponentFixture} from '@angular/core/testing';
-import {
-  MAT_CHIP_EDIT_INPUT_MANAGER,
-  MatChipEditInput,
-  MatChipEditInputDestroyEvent,
-  MatChipEditInputInterface,
-  MatChipEditInputManager,
-  MatChipsModule,
-} from './index';
+import {MatChipEditInput, MatChipsModule} from './index';
 import {By} from '@angular/platform-browser';
 
 
 describe('MDC-based MatChipEditInput', () => {
   const DEFAULT_INITIAL_VALUE = 'INITIAL_VALUE';
 
-  let testComponent: ChipEditInputContainer;
   let fixture: ComponentFixture<any>;
   let inputDebugElement: DebugElement;
   let inputInstance: MatChipEditInput;
@@ -28,91 +20,33 @@ describe('MDC-based MatChipEditInput', () => {
     });
 
     TestBed.compileComponents();
-  }));
 
-  function initialize(initialValue = DEFAULT_INITIAL_VALUE) {
     fixture = TestBed.createComponent(ChipEditInputContainer);
-    testComponent = fixture.debugElement.componentInstance;
-
-    spyOn(testComponent, 'onUpdate');
-    spyOn(testComponent, 'onDestroy');
-    spyOn(testComponent, 'setMatChipEditInput');
-    spyOn(testComponent, 'clearMatChipEditInput');
-
-    testComponent.initialValue = initialValue;
-    testComponent.active = true;
-    fixture.detectChanges();
-
     inputDebugElement = fixture.debugElement.query(By.directive(MatChipEditInput))!;
     inputInstance = inputDebugElement.injector.get<MatChipEditInput>(MatChipEditInput);
-  }
+  }));
 
   describe('on initialization', () => {
     it('should set the initial input text', () => {
-      initialize();
+      inputInstance.initialize(DEFAULT_INITIAL_VALUE);
       expect(inputInstance.getNativeElement().textContent).toEqual(DEFAULT_INITIAL_VALUE);
     });
 
     it('should focus the input', () => {
-      initialize();
+      inputInstance.initialize(DEFAULT_INITIAL_VALUE);
       expect(document.activeElement).toEqual(inputInstance.getNativeElement());
     });
-
-    it('should register itself with the injected manager', () => {
-      initialize();
-      expect(testComponent.setMatChipEditInput).toHaveBeenCalledWith(inputInstance);
-    });
   });
 
-  describe('on destruction', () => {
-    it('should emit hadFocus: true if the input had focus', () => {
-      initialize();
-      testComponent.active = false;
-      fixture.detectChanges();
-      expect(testComponent.onDestroy).toHaveBeenCalledWith({hadFocus: true});
-    });
-
-    it('should emit hadFocus: false if the input did not have focus', () => {
-      initialize();
-      testComponent.otherFocus.nativeElement.focus();
-      testComponent.active = false;
-      fixture.detectChanges();
-      expect(testComponent.onDestroy).toHaveBeenCalledWith({hadFocus: false});
-    });
-
-    it('should clear the manager\'s input', () => {
-      initialize();
-      testComponent.active = false;
-      fixture.detectChanges();
-      expect(testComponent.clearMatChipEditInput).toHaveBeenCalled();
-    });
-  });
-
-  it('should emit a new value the input changes', () => {
-    initialize();
+  it('should update the internal value as it is set', () => {
+    inputInstance.initialize(DEFAULT_INITIAL_VALUE);
     const newValue = 'NEW_VALUE';
     inputInstance.setValue(newValue);
-    expect(testComponent.onUpdate).toHaveBeenCalledWith(newValue);
+    expect(inputInstance.getValue()).toEqual(newValue);
   });
 });
 
 @Component({
-  template: `<mat-chip-edit-input *ngIf="active"
-                                  [initialValue]="initialValue"
-                                  (updated)="onUpdate($event)"
-                                  (destroyed)="onDestroy($event)"></mat-chip-edit-input>
-             <button #otherFocus></button>`,
-  providers: [{provide: MAT_CHIP_EDIT_INPUT_MANAGER, useExisting: ChipEditInputContainer}],
+  template: `<span matChipEditInput></span>`,
 })
-class ChipEditInputContainer implements MatChipEditInputManager {
-  active = false;
-  initialValue = '';
-
-  @ViewChild('otherFocus') otherFocus!: ElementRef;
-
-  onUpdate: (value: string) => void = () => {};
-  onDestroy: (event: MatChipEditInputDestroyEvent) => void = () => {};
-
-  setMatChipEditInput: (value: MatChipEditInputInterface) => void = () => {};
-  clearMatChipEditInput: () => void = () => {};
-}
+class ChipEditInputContainer {}

--- a/src/material-experimental/mdc-chips/chip-edit-input.ts
+++ b/src/material-experimental/mdc-chips/chip-edit-input.ts
@@ -7,101 +7,44 @@
  */
 
 import {
-  AfterViewInit,
-  ChangeDetectionStrategy,
-  Component,
+  Directive,
   ElementRef,
-  EventEmitter,
-  Inject,
-  InjectionToken,
-  Input,
-  OnDestroy,
-  Optional,
-  Output,
-  ViewChild,
-  ViewEncapsulation,
 } from '@angular/core';
 
-export interface MatChipEditInputDestroyEvent {
-  hadFocus: boolean;
-}
-
-export interface MatChipEditInputManager {
-  setMatChipEditInput(value: MatChipEditInputInterface): void;
-  clearMatChipEditInput(): void;
-}
-
-export const MAT_CHIP_EDIT_INPUT_MANAGER =
-    new InjectionToken<MatChipEditInputManager>('MAT_CHIP_EDIT_INPUT_MANAGER');
-
-export interface MatChipEditInputInterface {
-  getNativeElement(): HTMLElement;
-  setValue(value: string): void;
-}
-
 /**
- * A component that handles editing an existing chip and exposes itself to an optional injected
- * manager so parent components can extend the editing behavior.
+ * A directive that makes a span editable and exposes functions to modify and retrieve the
+ * element's contents.
  */
-@Component({
-  selector: 'mat-chip-edit-input',
-  templateUrl: 'chip-edit-input.html',
-  styleUrls: ['chips.css'],
-  inputs: ['initialValue'],
+@Directive({
+  selector: 'span[matChipEditInput]',
   host: {
-    '(input)': '_onInput()',
+    'class': 'mdc-chip__primary-action mat-chip-edit-input',
+    'role': 'textbox',
+    'tabindex': '-1',
+    'contenteditable': 'true',
   },
-  encapsulation: ViewEncapsulation.None,
-  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class MatChipEditInput implements AfterViewInit, OnDestroy, MatChipEditInputInterface {
-  @Input() initialValue = '';
-
-  @Output() readonly updated = new EventEmitter<string>();
-
-  @Output() readonly destroyed = new EventEmitter<MatChipEditInputDestroyEvent>();
-
-  @ViewChild('inputElement') inputElement!: ElementRef;
-
+export class MatChipEditInput {
   constructor(
-      @Optional() @Inject(MAT_CHIP_EDIT_INPUT_MANAGER)
-      private readonly _inputManager: MatChipEditInputManager,
-  ) {
-    if (_inputManager) {
-      _inputManager.setMatChipEditInput(this);
-    }
-  }
+      private readonly _elementRef: ElementRef,
+  ) {}
 
-  ngAfterViewInit() {
-    this.getNativeElement().innerText = this.initialValue;
+  initialize(initialValue: string) {
     this.getNativeElement().focus();
-    this._moveCursorToEndOfInput();
-  }
-
-  ngOnDestroy() {
-    this.destroyed.emit({
-      // We assume the input had focus if it is still the active element or the body
-      // has become the active element on destroy.
-      hadFocus: document.activeElement === this.getNativeElement() ||
-                document.activeElement === document.body,
-    });
-    if (this._inputManager) {
-      this._inputManager.clearMatChipEditInput();
-    }
+    this.setValue(initialValue);
   }
 
   getNativeElement(): HTMLElement {
-    return this.inputElement.nativeElement;
+    return this._elementRef.nativeElement;
   }
 
   setValue(value: string) {
     this.getNativeElement().innerText = value;
-    this._onInput();
+    this._moveCursorToEndOfInput();
   }
 
-  _onInput() {
-    this.updated.emit(
-        this.getNativeElement().textContent!.trim());
+  getValue(): string {
+    return this.getNativeElement().textContent || '';
   }
 
   private _moveCursorToEndOfInput() {

--- a/src/material-experimental/mdc-chips/chip-row.html
+++ b/src/material-experimental/mdc-chips/chip-row.html
@@ -24,9 +24,9 @@
 </div>
 
 <div *ngIf="_isEditing()" role="gridcell" class="mat-chip-edit-input-container">
-  <ng-content *ngIf="contentEditInput; else defaultMatChipEditInput" select="[matChipEditInput]"></ng-content>
+  <ng-content *ngIf="contentEditInput; else defaultMatChipEditInput"
+              select="[matChipEditInput]"></ng-content>
+  <ng-template #defaultMatChipEditInput>
+    <span matChipEditInput></span>
+  </ng-template>
 </div>
-
-<ng-template #defaultMatChipEditInput>
-  <span matChipEditInput></span>
-</ng-template>

--- a/src/material-experimental/mdc-chips/chip-row.html
+++ b/src/material-experimental/mdc-chips/chip-row.html
@@ -24,7 +24,9 @@
 </div>
 
 <div *ngIf="_isEditing()" role="gridcell" class="mat-chip-edit-input-container">
-  <mat-chip-edit-input [initialValue]="_editingValue"
-                       (updated)="_onInputUpdated($event)"
-                       (destroyed)="_onInputDestroyed($event)"></mat-chip-edit-input>
+  <ng-content *ngIf="contentEditInput; else defaultMatChipEditInput" select="[matChipEditInput]"></ng-content>
 </div>
+
+<ng-template #defaultMatChipEditInput>
+  <span matChipEditInput></span>
+</ng-template>

--- a/src/material-experimental/mdc-chips/chip-row.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-row.spec.ts
@@ -6,12 +6,13 @@ import {
   createFakeEvent,
   dispatchFakeEvent,
 } from '@angular/cdk/testing/private';
-import {Component, DebugElement, ViewChild} from '@angular/core';
+import {Component, DebugElement, ElementRef, ViewChild} from '@angular/core';
 import {async, ComponentFixture, TestBed, flush, fakeAsync} from '@angular/core/testing';
 import {By} from '@angular/platform-browser';
 import {Subject} from 'rxjs';
 import {
   MatChipEditedEvent,
+  MatChipEditInput,
   MatChipEvent,
   MatChipGrid,
   MatChipRemove,
@@ -259,11 +260,21 @@ describe('MDC-based Row Chips', () => {
     });
 
     describe('editing behavior', () => {
+      let editInputInstance: MatChipEditInput;
+      let chipContentElement: HTMLElement;
+
       beforeEach(() => {
         testComponent.editable = true;
         fixture.detectChanges();
         chipInstance._dblclick(createMouseEvent('dblclick'));
         spyOn(testComponent, 'chipEdit');
+        fixture.detectChanges();
+
+        const editInputDebugElement = fixture.debugElement.query(By.directive(MatChipEditInput))!;
+        editInputInstance = editInputDebugElement.injector.get<MatChipEditInput>(MatChipEditInput);
+
+        chipContentElement =
+          chipNativeElement.querySelector('.mat-chip-row-focusable-text-content') as HTMLElement;
       });
 
       function keyDownOnPrimaryAction(keyCode: number, key: string) {
@@ -303,10 +314,33 @@ describe('MDC-based Row Chips', () => {
 
       it('should emit the new chip value when editing completes', () => {
         const chipValue = 'chip value';
-        chipInstance._onInputUpdated(chipValue);
+        editInputInstance.setValue(chipValue);
         keyDownOnPrimaryAction(ENTER, 'Enter');
         const expectedValue = jasmine.objectContaining({value: chipValue});
         expect(testComponent.chipEdit).toHaveBeenCalledWith(expectedValue);
+      });
+
+      it('should focus the chip content if the edit input has focus on completion', () => {
+        const chipValue = 'chip value';
+        editInputInstance.setValue(chipValue);
+        keyDownOnPrimaryAction(ENTER, 'Enter');
+        expect(document.activeElement).toBe(chipContentElement);
+      });
+
+      it('should focus the chip content if the body has focus on completion', () => {
+        const chipValue = 'chip value';
+        editInputInstance.setValue(chipValue);
+        (document.activeElement as HTMLElement).blur();
+        keyDownOnPrimaryAction(ENTER, 'Enter');
+        expect(document.activeElement).toBe(chipContentElement);
+      });
+
+      it('should not change focus if another element has focus on completion', () => {
+        const chipValue = 'chip value';
+        editInputInstance.setValue(chipValue);
+        testComponent.chipInput.nativeElement.focus();
+        keyDownOnPrimaryAction(ENTER, 'Enter');
+        expect(document.activeElement).not.toBe(chipContentElement);
       });
     });
   });
@@ -322,13 +356,15 @@ describe('MDC-based Row Chips', () => {
                  (removed)="chipRemove($event)" (edited)="chipEdit($event)">
           {{name}}
           <button matChipRemove>x</button>
+          <span matChipEditInput></span>
         </mat-chip-row>
-        <input matInput [matChipInputFor]="chipGrid">
+        <input matInput [matChipInputFor]="chipGrid" #chipInput>
       </div>
     </mat-chip-grid>`
 })
 class SingleChip {
   @ViewChild(MatChipGrid) chipList: MatChipGrid;
+  @ViewChild('chipInput') chipInput: ElementRef;
   disabled: boolean = false;
   name: string = 'Test';
   color: string = 'primary';

--- a/src/material-experimental/mdc-chips/chip-row.spec.ts
+++ b/src/material-experimental/mdc-chips/chip-row.spec.ts
@@ -320,6 +320,22 @@ describe('MDC-based Row Chips', () => {
         expect(testComponent.chipEdit).toHaveBeenCalledWith(expectedValue);
       });
 
+      it('should use the projected edit input if provided', () => {
+        expect(editInputInstance.getNativeElement()).toHaveClass('projected-edit-input');
+      });
+
+      it('should use the default edit input if none is projected', () => {
+        keyDownOnPrimaryAction(ENTER, 'Enter');
+        testComponent.useCustomEditInput = false;
+        fixture.detectChanges();
+        chipInstance._dblclick(createMouseEvent('dblclick'));
+        fixture.detectChanges();
+        const editInputDebugElement = fixture.debugElement.query(By.directive(MatChipEditInput))!;
+        const editInputNoProject =
+          editInputDebugElement.injector.get<MatChipEditInput>(MatChipEditInput);
+        expect(editInputNoProject.getNativeElement()).not.toHaveClass('projected-edit-input');
+      });
+
       it('should focus the chip content if the edit input has focus on completion', () => {
         const chipValue = 'chip value';
         editInputInstance.setValue(chipValue);
@@ -356,7 +372,7 @@ describe('MDC-based Row Chips', () => {
                  (removed)="chipRemove($event)" (edited)="chipEdit($event)">
           {{name}}
           <button matChipRemove>x</button>
-          <span matChipEditInput></span>
+          <span *ngIf="useCustomEditInput" class="projected-edit-input" matChipEditInput></span>
         </mat-chip-row>
         <input matInput [matChipInputFor]="chipGrid" #chipInput>
       </div>
@@ -371,6 +387,7 @@ class SingleChip {
   removable: boolean = true;
   shouldShow: boolean = true;
   editable: boolean = false;
+  useCustomEditInput: boolean = true;
 
   chipFocus: (event?: MatChipEvent) => void = () => {};
   chipDestroy: (event?: MatChipEvent) => void = () => {};

--- a/src/material-experimental/mdc-chips/chip.ts
+++ b/src/material-experimental/mdc-chips/chip.ts
@@ -146,9 +146,6 @@ export class MatChip extends _MatChipMixinBase implements AfterContentInit, Afte
   /** Whether the chip has focus. */
   protected _hasFocusInternal = false;
 
-  /** The value of the chip as it is being edited. */
-  protected _editingValueInternal = '';
-
     /** Whether animations for the chip are enabled. */
   _animationsDisabled: boolean;
 
@@ -164,10 +161,6 @@ export class MatChip extends _MatChipMixinBase implements AfterContentInit, Afte
 
   get _hasFocus() {
     return this._hasFocusInternal;
-  }
-
-  get _editingValue() {
-    return this._editingValueInternal;
   }
 
   /** Default unique id for the chip. */
@@ -301,13 +294,12 @@ export class MatChip extends _MatChipMixinBase implements AfterContentInit, Afte
         },
     notifyEditStart:
         () => {
-          this._editingValueInternal = this.value;
+          this._onEditStart();
           this._changeDetectorRef.markForCheck();
         },
     notifyEditFinish:
         () => {
-          this.edited.emit({chip: this, value: this._editingValue});
-          this._editingValueInternal = '';
+          this._onEditFinish();
           this._changeDetectorRef.markForCheck();
         },
     getComputedStyleValue:
@@ -494,6 +486,12 @@ export class MatChip extends _MatChipMixinBase implements AfterContentInit, Afte
   _isEditing() {
     return this._chipFoundation.isEditing();
   }
+
+  /** Overridden by MatChipRow. */
+  protected _onEditStart() {}
+
+  /** Overridden by MatChipRow. */
+  protected _onEditFinish() {}
 
   static ngAcceptInputType_disabled: BooleanInput;
   static ngAcceptInputType_removable: BooleanInput;


### PR DESCRIPTION
Changes matChipEditInput into a directive to better match established patterns used by things like matChipRemove to dictate the behavior of an edit input from within a chip while still letting the host component have some control over the input.